### PR TITLE
Add ability to move a task's position within the list

### DIFF
--- a/bin/pomo
+++ b/bin/pomo
@@ -237,3 +237,17 @@ command :list do |c|
   end
 end
 
+command :move do |c|
+  c.syntax = 'pomo move [from] [to]'
+  c.description = 'Move a task to a different position'
+  c.example 'Move task 4 to position 2', 'pomo move 4 2'
+  c.example 'Move last task to first position', 'pomo move last first'
+  c.action do |args|
+    list.find(args[0]) do |task, i|
+      list.move(args[0], args[1])
+      say "  - moved #{task} from position #{args[0]} to #{args[1]}" 
+    end
+    list.save
+  end
+end
+

--- a/bin/pomo
+++ b/bin/pomo
@@ -251,3 +251,18 @@ command :move do |c|
   end
 end
 
+command :duplicate do |c|
+  c.syntax = 'pomo duplicate [task]'
+  c.summary = 'Duplicate a task'
+  c.description = 'Duplicate a task, adding the duplicated task to the end of the list'
+  c.example 'Duplicate the first task', 'pomo duplicate first'
+  c.example 'Duplicate task 4', 'pomo duplicate 4'
+  c.action do |args|
+    list.find(args[0]) do |task, i|
+      list.add(task) 
+      say "  - duplicated #{task}"
+    end
+    list.save
+  end
+end
+

--- a/bin/pomo
+++ b/bin/pomo
@@ -257,10 +257,15 @@ command :duplicate do |c|
   c.description = 'Duplicate a task, adding the duplicated task to the end of the list'
   c.example 'Duplicate the first task', 'pomo duplicate first'
   c.example 'Duplicate task 4', 'pomo duplicate 4'
-  c.action do |args|
+  c.example 'Duplicate the last task 5 times', 'pomo duplicate last -n 5'
+  c.option '-n', '--number times', Integer, 'Duplicate a number times'
+  c.action do |args, options|
+    options.default :number => 1
     list.find(args[0]) do |task, i|
-      list.add(task) 
-      say "  - duplicated #{task}"
+      options.number.times do
+        list.add(task.dup) 
+        say "  - duplicated #{task}"
+      end
     end
     list.save
   end

--- a/lib/pomo/list.rb
+++ b/lib/pomo/list.rb
@@ -71,18 +71,14 @@ module Pomo
     alias :<< :add
 
     ##
-    ## Move _task_ from current position to new position (requres saving).
+    ## Move task at _from_ position to new _to_ position (requres saving).
 
     def move from, to
-      list = []
+      list = Array.new(@tasks.size)
+      list[position(to)] = @tasks[position(from)]
       @tasks.each_with_index do |task, index|
         next if index == position(from)
-        if index == position(to)
-          list << @tasks[position(from)]
-          list << task
-        else
-          list << task
-        end
+        list[list.find_index(nil)] = task
       end
       @tasks = list
     end
@@ -104,12 +100,15 @@ module Pomo
       @tasks = YAML.load_file path
       self
     end
-  
+
+    ## 
+    # Determine position from argument.
+
     def position arg
       return case arg.downcase
         when 'first' then 0
         when 'last' then @tasks.size-1
-        else arg.to_i
+        else arg.to_i > @tasks.size-1 ? @tasks.size-1 : arg.to_i
         end
     end
     private :position

--- a/lib/pomo/list.rb
+++ b/lib/pomo/list.rb
@@ -69,6 +69,23 @@ module Pomo
       @tasks << task
     end
     alias :<< :add
+
+    ##
+    ## Move _task_ from current position to new position (requres saving).
+
+    def move from, to
+      list = []
+      @tasks.each_with_index do |task, index|
+        next if index == position(from)
+        if index == position(to)
+          list << @tasks[position(from)]
+          list << task
+        else
+          list << task
+        end
+      end
+      @tasks = list
+    end
     
     ##
     # Save the list.
@@ -87,6 +104,14 @@ module Pomo
       @tasks = YAML.load_file path
       self
     end
-    
+  
+    def position arg
+      return case arg.downcase
+        when 'first' then 0
+        when 'last' then @tasks.size-1
+        else arg.to_i
+        end
+    end
+    private :position
   end
 end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -1,0 +1,81 @@
+
+require File.dirname(__FILE__) + '/spec_helper'
+require 'fileutils'
+
+describe Pomo::List do
+  before :each do
+    @path = File.join(File.dirname(__FILE__), 'pomo_test.dat')
+    @list = Pomo::List.new(@path)
+    5.times { |i| @list.add Pomo::Task.new("Task #{i}") }
+  end
+
+  after :each do
+    FileUtils::rm(@path)
+  end
+
+  it "stores a path for persistence of data" do
+    @list.path.should == @path
+  end
+
+  it "can store tasks" do
+    @list.tasks.size.should == 5
+  end
+
+  it "can persist to disk" do
+    @list.save
+    File.exist?(@path).should be_true
+  end
+
+  it "can load from disk" do
+    @list.save
+    @list = Pomo::List.new(@path)
+    @list.load # not specifically needed, called upon initialization
+    @list.tasks.first.should == 'Task 0'
+  end
+
+  it "can find all tasks" do
+    @list.find('all') do |task, i|
+      task.name.should == "Task #{i}"
+    end
+  end
+
+  it "can find the first task" do
+    @list.find('first') do |task, i|
+      task.name.should == 'Task 0'
+    end
+  end
+
+  it "can find the last task" do
+    @list.find('last') do |task, i|
+      task.name.should == 'Task 4'
+    end
+  end
+
+  it "can find complete tasks" do
+    @list.tasks[2].complete = true
+    @list.find('complete') do |task, i|
+      task.name.should == 'Task 2'
+    end
+  end
+
+  it "can find incomplete tasks" do
+    @list.tasks[0].complete = true
+    @list.find('incomplete') do |task, i|
+      task.name.should == "Task #{i+1}"
+    end
+  end
+
+  it "can find a task by number" do
+    @list.find(2) do |task, i|
+      task.name.should == 'Task 2'
+    end
+  end
+
+  it "can find a range of tasks" do
+    names = ['Task 3', 'Task 4']
+    @list.find('3..4') do |task, i|
+      task.name.should == names.shift
+    end
+  end
+end
+

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -30,7 +30,7 @@ describe Pomo::List do
     @list.save
     @list = Pomo::List.new(@path)
     @list.load # not specifically needed, called upon initialization
-    @list.tasks.first.should == 'Task 0'
+    @list.tasks.first.name.should == 'Task 0'
   end
 
   it "can find all tasks" do
@@ -76,6 +76,43 @@ describe Pomo::List do
     @list.find('3..4') do |task, i|
       task.name.should == names.shift
     end
+  end
+
+  it "can move a task's position from first to last" do
+    @list.move('first', 'last')
+    @list.tasks.first.name.should == 'Task 1'
+    @list.tasks.last.name.should == 'Task 0'
+  end
+
+  it "can move a task's position from last to first" do
+    @list.move('last', 'first')
+    @list.tasks.first.name.should == 'Task 4'
+    @list.tasks.last.name.should == 'Task 3'
+  end
+
+  it "can move a task's position with numbers forwards" do
+    @list.move('1', '3')
+    @list.tasks[0].name.should == 'Task 0'
+    @list.tasks[1].name.should == 'Task 2'
+    @list.tasks[2].name.should == 'Task 3'
+    @list.tasks[3].name.should == 'Task 1'
+    @list.tasks[4].name.should == 'Task 4'
+  end
+
+  it "can move a task's position with numbers backwards" do
+    @list.move('3', '1')
+    @list.tasks[0].name.should == 'Task 0'
+    @list.tasks[1].name.should == 'Task 3'
+    @list.tasks[2].name.should == 'Task 1'
+    @list.tasks[3].name.should == 'Task 2'
+    @list.tasks[4].name.should == 'Task 4'
+  end
+
+  it "uses equivalent of 'last' for all arguments larger than size of task list" do
+    @list.move('first', '100')
+    @list.tasks.first.name.should == 'Task 1'
+    @list.tasks[4].name.should == 'Task 0'
+    @list.tasks.size.should == 5
   end
 end
 

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -32,9 +32,5 @@ describe Pomo::Task do
     @task.complete = true
     @task.should be_complete
   end
-
-  it "can be started" do
-    pending 'not sure how to spec the progress bar'
-  end
 end
 

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -1,0 +1,40 @@
+
+require File.dirname(__FILE__) + '/spec_helper'
+
+describe Pomo::Task do
+  before :each do
+    @task = Pomo::Task.new('test task')
+  end
+
+  it "has a name" do
+    @task.name.should == 'test task'
+  end
+
+  it "has a default length" do
+    @task.length.should == 25
+  end
+
+  it "is not complete by default" do
+    @task.should_not be_complete
+  end
+
+  it "can change its name" do
+    @task.name = 'another task'
+    @task.name.should == 'another task'
+  end
+
+  it "can change its length" do
+    @task.length = 30
+    @task.length.should == 30
+  end
+
+  it "can be completed" do
+    @task.complete = true
+    @task.should be_complete
+  end
+
+  it "can be started" do
+    pending 'not sure how to spec the progress bar'
+  end
+end
+

--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -1,25 +1,22 @@
 
-require 'spec/rake/spectask'
+require 'rspec/core/rake_task'
   
 desc "Run all specifications"
-Spec::Rake::SpecTask.new(:spec) do |t|
-  t.libs << "lib"
-  t.spec_opts = ["--color", "--require", "spec/spec_helper.rb"]
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = ["--color"]
 end
   
 namespace :spec do
 
   desc "Run all specifications verbosely"
-  Spec::Rake::SpecTask.new(:verbose) do |t|
-    t.libs << "lib"
-    t.spec_opts = ["--color", "--format", "specdoc", "--require", "spec/spec_helper.rb"]
+  RSpec::Core::RakeTask.new(:verbose) do |t|
+    t.rspec_opts = ["--color", "--format", "documentation"]
   end
   
   desc "Run specific specification verbosely (specify SPEC)"
-  Spec::Rake::SpecTask.new(:select) do |t|
-    t.libs << "lib"
-    t.spec_files = [ENV["SPEC"]]
-    t.spec_opts = ["--color", "--format", "specdoc", "--require", "spec/spec_helper.rb"]
+  RSpec::Core::RakeTask.new(:select) do |t|
+    t.pattern = [ENV["SPEC"]]
+    t.rspec_opts = ["--color", "--format", "documentation"]
   end
   
 end


### PR DESCRIPTION
Like the subject states, I added the ability to move a task's position within the task list. Also added some specs to help in developing the change. I think these may be useful to pull in.

I'd also like to add some other features relatively soon ... tags or categories or projects, not sure what to call it. I usually title a pomodoro with "Project: Title of pomodoro", and it'd be nice to keep track of a project so that you can list only pomodoros in a certain project for example.

Let me know what you think about that when you have the time.

And of course, thanks for writing this great little tool!
