### PR TITLE
uninitialized constant Pomo::Notifier::QuicksilverNotifier

### DIFF
--- a/lib/pomo/notifier.rb
+++ b/lib/pomo/notifier.rb
@@ -1,6 +1,7 @@
 require 'pomo/notifier/growl_notifier'
 require 'pomo/notifier/libnotify_notifier'
 require 'pomo/notifier/notification_center_notifier'
+require 'pomo/notifier/quicksilver_notifier'
 
 module Pomo
   class Notifier


### PR DESCRIPTION
error: uninitialized constant Pomo::Notifier::QuicksilverNotifier. Use --trace to view backtrace
