### PR TITLE
Typo in os.rb prevents detecting linux environment

### DIFF
--- a/lib/pomo/os.rb
+++ b/lib/pomo/os.rb
@@ -5,7 +5,7 @@ module Pomo
     module_function
 
     def linux?
-      (/linux/ =~ RbConfig::CONFIG['host_os']) !=nil
+      (/linux/ =~ RbConfig::CONFIG['host_os']) != nil
     end
 
     def mac?


### PR DESCRIPTION
It seems silly, but I tested locally and that's all it takes to load libnotify gem as a dependency when building.
