### PR TITLE
Fix travis ci build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pomo [![Build Status](https://travis-ci.org/visionmedia/pomo.png?branch=master)](https://travis-ci.org/visionmedia/pomo) [![Dependency Status](https://gemnasium.com/visionmedia/pomo.png)](https://gemnasium.com/visionmedia/pomo) [![Code Climate](https://codeclimate.com/github/visionmedia/pomo.png)](https://codeclimate.com/github/visionmedia/pomo)
+# Pomo [![Build Status](https://travis-ci.org/tj/pomo.svg?branch=master)](https://travis-ci.org/tj/pomo) [![Dependency Status](https://gemnasium.com/visionmedia/pomo.png)](https://gemnasium.com/visionmedia/pomo) [![Code Climate](https://codeclimate.com/github/visionmedia/pomo.png)](https://codeclimate.com/github/visionmedia/pomo)
 
 Command-line application for the [Pomodoro](http://www.pomodorotechnique.com/)
 time management technique, with notification and tmux status bar support.


### PR DESCRIPTION
The URL to the TravisCI build status badge was wrong. This PR fixes URL.
